### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/mcafee-epo-agenthandler.template
+++ b/templates/mcafee-epo-agenthandler.template
@@ -973,7 +973,7 @@ Resources:
           AGGREGATOR_ALAM_NAME: !Sub ${AWS::StackName}-AggregatorAlarm
       Handler: metric-aggregator.handler
       Role: !GetAtt AHMetricAggregatorLambdaRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 120
       Tags:
         - Key: Name


### PR DESCRIPTION
CloudFormation templates in quickstart-mcafee-epo have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.